### PR TITLE
Fix the bug of the "removePod" function in node_info.go

### DIFF
--- a/plugin/pkg/scheduler/schedulercache/node_info.go
+++ b/plugin/pkg/scheduler/schedulercache/node_info.go
@@ -135,7 +135,7 @@ func (n *NodeInfo) removePod(pod *api.Pod) error {
 	for i := range n.pods {
 		k2, err := getPodKey(n.pods[i])
 		if err != nil {
-			glog.Errorf("Cannot get node.pod(%s/%s) key, err: %v", n.pods[i].Namespace, n.pods[i].Name, err)
+			glog.Errorf("Cannot get pod key, err: %v", err)
 			continue
 		}
 		if k1 == k2 {
@@ -152,7 +152,7 @@ func (n *NodeInfo) removePod(pod *api.Pod) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("no corresponding pod(%s/%s) in pods of node(%s)", pod.Namespace, pod.Name, n.node.Name)
+	return fmt.Errorf("no corresponding pod %s in pods of node %s", pod.Name, n.node.Name)
 }
 
 func calculateResource(pod *api.Pod) (cpu int64, mem int64, nvidia_gpu int64, non0_cpu int64, non0_mem int64) {

--- a/plugin/pkg/scheduler/schedulercache/node_info.go
+++ b/plugin/pkg/scheduler/schedulercache/node_info.go
@@ -132,27 +132,27 @@ func (n *NodeInfo) removePod(pod *api.Pod) error {
 		return err
 	}
 
-	cpu, mem, nvidia_gpu, non0_cpu, non0_mem := calculateResource(pod)
-	n.requestedResource.MilliCPU -= cpu
-	n.requestedResource.Memory -= mem
-	n.requestedResource.NvidiaGPU -= nvidia_gpu
-	n.nonzeroRequest.MilliCPU -= non0_cpu
-	n.nonzeroRequest.Memory -= non0_mem
-
 	for i := range n.pods {
 		k2, err := getPodKey(n.pods[i])
 		if err != nil {
-			glog.Errorf("Cannot get pod key, err: %v", err)
+			glog.Errorf("Cannot get node.pod(%s/%s) key, err: %v", n.pods[i].Namespace, n.pods[i].Name, err)
 			continue
 		}
 		if k1 == k2 {
 			// delete the element
 			n.pods[i] = n.pods[len(n.pods)-1]
 			n.pods = n.pods[:len(n.pods)-1]
+			// reduce the resource data
+			cpu, mem, nvidia_gpu, non0_cpu, non0_mem := calculateResource(pod)
+			n.requestedResource.MilliCPU -= cpu
+			n.requestedResource.Memory -= mem
+			n.requestedResource.NvidiaGPU -= nvidia_gpu
+			n.nonzeroRequest.MilliCPU -= non0_cpu
+			n.nonzeroRequest.Memory -= non0_mem
 			return nil
 		}
 	}
-	return fmt.Errorf("no corresponding pod in pods")
+	return fmt.Errorf("no corresponding pod(%s/%s) in pods of node(%s)", pod.Namespace, pod.Name, n.node.Name)
 }
 
 func calculateResource(pod *api.Pod) (cpu int64, mem int64, nvidia_gpu int64, non0_cpu int64, non0_mem int64) {


### PR DESCRIPTION
It should reduce the resource data after finding the pod in the pods, because perhaps no corresponding pod in the pods of the node, at this time it shouldn't reduce the resource data of the node.
