### PR TITLE
Add the length detection of the "predicateFuncs" in generic_scheduler.go

### DIFF
--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -140,7 +140,6 @@ func findNodesThatFit(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.No
 	filtered := []api.Node{}
 	failedPredicateMap := FailedPredicateMap{}
 
-	//wp:#25606
 	if len(predicateFuncs) == 0 {
 		filtered = nodes.Items
 	} else {
@@ -174,24 +173,6 @@ func findNodesThatFit(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.No
 			if err != nil {
 				return api.NodeList{}, FailedPredicateMap{}, err
 			}
-			//add the extender failed info to failedPredicateMap wp:#25797
-			for _, filteredNode := range filtered {
-				nodeIn := false
-				for _, exNode := range filteredList.Items {
-					if filteredNode.Name == exNode.Name {
-						nodeIn = true
-						break
-					}
-				}
-				if !nodeIn {
-					if re, ok := extender.(*HTTPExtender); ok {
-						failedPredicateMap[filteredNode.Name] = fmt.Sprintf("%s, %s", re.extenderURL, re.filterVerb)
-					} else {
-						failedPredicateMap[filteredNode.Name] = "extender failed"
-					}
-				}
-			}
-
 			filtered = filteredList.Items
 			if len(filtered) == 0 {
 				break

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -137,30 +137,34 @@ func (g *genericScheduler) selectHost(priorityList schedulerapi.HostPriorityList
 // Filters the nodes to find the ones that fit based on the given predicate functions
 // Each node is passed through the predicate functions to determine if it is a fit
 func findNodesThatFit(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.NodeInfo, predicateFuncs map[string]algorithm.FitPredicate, nodes api.NodeList, extenders []algorithm.SchedulerExtender) (api.NodeList, FailedPredicateMap, error) {
-	predicateResultLock := sync.Mutex{}
 	filtered := []api.Node{}
 	failedPredicateMap := FailedPredicateMap{}
-	errs := []error{}
 
-	checkNode := func(i int) {
-		nodeName := nodes.Items[i].Name
-		fits, failedPredicate, err := podFitsOnNode(pod, nodeNameToInfo[nodeName], predicateFuncs)
-
-		predicateResultLock.Lock()
-		defer predicateResultLock.Unlock()
-		if err != nil {
-			errs = append(errs, err)
-			return
+	if len(predicateFuncs) == 0 {
+		filtered = nodes.Items
+	} else {
+		predicateResultLock := sync.Mutex{}
+		errs := []error{}
+		checkNode := func(i int) {
+			nodeName := nodes.Items[i].Name
+			fits, failedPredicate, err := podFitsOnNode(pod, nodeNameToInfo[nodeName], predicateFuncs)
+	
+			predicateResultLock.Lock()
+			defer predicateResultLock.Unlock()
+			if err != nil {
+				errs = append(errs, err)
+				return
+			}
+			if fits {
+				filtered = append(filtered, nodes.Items[i])
+			} else {
+				failedPredicateMap[nodeName] = failedPredicate
+			}
 		}
-		if fits {
-			filtered = append(filtered, nodes.Items[i])
-		} else {
-			failedPredicateMap[nodeName] = failedPredicate
+		workqueue.Parallelize(16, len(nodes.Items), checkNode)
+		if len(errs) > 0 {
+			return api.NodeList{}, FailedPredicateMap{}, errors.NewAggregate(errs)
 		}
-	}
-	workqueue.Parallelize(16, len(nodes.Items), checkNode)
-	if len(errs) > 0 {
-		return api.NodeList{}, FailedPredicateMap{}, errors.NewAggregate(errs)
 	}
 
 	if len(filtered) > 0 && len(extenders) != 0 {

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -140,6 +140,7 @@ func findNodesThatFit(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.No
 	filtered := []api.Node{}
 	failedPredicateMap := FailedPredicateMap{}
 
+	//wp:#25606
 	if len(predicateFuncs) == 0 {
 		filtered = nodes.Items
 	} else {
@@ -148,7 +149,7 @@ func findNodesThatFit(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.No
 		checkNode := func(i int) {
 			nodeName := nodes.Items[i].Name
 			fits, failedPredicate, err := podFitsOnNode(pod, nodeNameToInfo[nodeName], predicateFuncs)
-	
+
 			predicateResultLock.Lock()
 			defer predicateResultLock.Unlock()
 			if err != nil {
@@ -173,6 +174,24 @@ func findNodesThatFit(pod *api.Pod, nodeNameToInfo map[string]*schedulercache.No
 			if err != nil {
 				return api.NodeList{}, FailedPredicateMap{}, err
 			}
+			//add the extender failed info to failedPredicateMap wp:#25797
+			for _, filteredNode := range filtered {
+				nodeIn := false
+				for _, exNode := range filteredList.Items {
+					if filteredNode.Name == exNode.Name {
+						nodeIn = true
+						break
+					}
+				}
+				if !nodeIn {
+					if re, ok := extender.(*HTTPExtender); ok {
+						failedPredicateMap[filteredNode.Name] = fmt.Sprintf("%s, %s", re.extenderURL, re.filterVerb)
+					} else {
+						failedPredicateMap[filteredNode.Name] = "extender failed"
+					}
+				}
+			}
+
 			filtered = filteredList.Items
 			if len(filtered) == 0 {
 				break


### PR DESCRIPTION
The PR add the length detection of the "predicateFuncs" for "findNodesThatFit" function of generic_scheduler.go. 
In “findNodesThatFit” function, if the length of the "predicateFuncs" parameter is 0, it can set filtered equals nodes.Items, and needn't to traverse the nodes.Items.
